### PR TITLE
Fixing listener use on component lifecycle

### DIFF
--- a/react/index.tsx
+++ b/react/index.tsx
@@ -16,14 +16,19 @@ class CheckoutButtonExample extends Component<{}, CheckoutButtonExampleState> {
     }
   }
 
-  listenOrderFormUpdated() {
-    $(window).on('orderFormUpdated.vtex', (_: any, orderForm: OrderForm) =>
-      this.setState({ orderForm })
-    )
+  setOrderForm = (_: any, orderForm: OrderForm) => {
+    this.setState({ orderForm })
+  }
+
+  componentDidMount() {
+    $(window).on('orderFormUpdated.vtex', this.setOrderForm)
+  }
+
+  componentWillUnmount() {
+    $(window).off('orderFormUpdated.vtex', this.setOrderForm)
   }
 
   render() {
-    this.listenOrderFormUpdated()
     console.log(window.vtex.i18n.getLocale())
 
     return <CustomButton {...this.state.orderForm!} />

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,6 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-intl": "^2.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2525,10 +2525,10 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uncontrollable@^6.0.0:
   version "6.2.3"


### PR DESCRIPTION
Changes use of listener, moving its use from the `render` method to the `componentDidMount` and adding an "unlisten" method on `componentWillUnmount`